### PR TITLE
Feat/result page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import "./App.css";
 import Mockman from "mockman-js";
 import {Routes, Route, Link} from 'react-router-dom';
 //pages
-import { CategoryPage, HomePage, RulesPage } from "./pages";
+import { CategoryPage, HomePage, RulesPage, ResultsPage } from "./pages";
 import QuizPage from "./pages/quiz/QuizPage";
 
 
@@ -16,6 +16,7 @@ function App() {
         <Route path="/rules" element={<RulesPage/>}/>
         <Route path="/category-page" element={<CategoryPage/>} />
         <Route path="/quiz-page" element={<QuizPage/>} />
+        <Route path="/results-page" element={<ResultsPage />} />
         <Route path="/mock" element={<Mockman/>}/>
         <Route path="*" element={<div>Not Found - 404</div>} />
       </Routes>

--- a/src/context/quiz-context.js
+++ b/src/context/quiz-context.js
@@ -7,7 +7,7 @@ const QuizContext = createContext();
 //provide context 
 const QuizProvider = ({children}) => {
 
-
+    const [correctCount, setCorrectCount] = useState(0)
     const [mcqs, setMcqs] = useState({
         step: 0,
         // step: 0,
@@ -19,7 +19,7 @@ const QuizProvider = ({children}) => {
     })
 
     return(
-        <QuizContext.Provider value={{mcqs, setMcqs}}>
+        <QuizContext.Provider value={{mcqs, setMcqs, correctCount, setCorrectCount}}>
             {children}
         </QuizContext.Provider>
     )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import HomePage from "./home-page/HomePage";
 import RulesPage from "./rules-page/RulesPage";
 import CategoryPage from "./category-page/CategoryPage";
+import ResultsPage from "./results-page/ResultsPage";
 
-export {HomePage, RulesPage, CategoryPage};
+export {HomePage, RulesPage, CategoryPage, ResultsPage};

--- a/src/pages/quiz/QuizPage.jsx
+++ b/src/pages/quiz/QuizPage.jsx
@@ -1,44 +1,41 @@
 import { useEffect } from "react";
-import { useQuiz } from "../../context/quiz-context"
+import { useQuiz } from "../../context/quiz-context";
+import {useNavigate, Navigate} from "react-router-dom";
 
-/**
- * correctCount inside QuizPage re-renders on each question, so at max it can
- * be 1. This was the bug, can be solved if using a state variable?
- * But, if that updates, it will make the QuizPage rerender
- * 
- */
-let correctCount = 0;
 
 
 export default function QuizPage() {
 
-    
+    const navigate = useNavigate();
+    const { mcqs, setMcqs} = useQuiz();
+    const {correctCount, setCorrectCount} = useQuiz();
 
-    function checkAnswer(correctAns, clickedAns) {
-        console.log(`correctAns-${correctAns} || clickedAns-${clickedAns}`);
+    console.log("mcqs Obj in QuizPage - ", mcqs)
+
+    function checkAnswer(correctAns, clickedAns, clickedOptionQuestionId) {
+
         if(correctAns === clickedAns){
-            console.log("correctCount before-", correctCount)
-            correctCount++
-            console.log("correctCount after-", correctCount)
+            console.log("correctCount before: ", correctCount)
+            setCorrectCount(prev => prev+1)
+            console.log("correctCount after: ", correctCount)
+        //Bug - clicking on correct option keeps increasing the count. Should increase only once
         }
+
+        //save the 'clicked' option by modifying mcqs data structure
+        setMcqs(prev => {
+            return {
+                ...prev,
+                questions: [...prev.questions.map(question => {
+                //set clicked flag for one question at a time in questions array
+                    if (question._id === clickedOptionQuestionId){
+                        return {...question, clicked: clickedAns}
+                    }
+                    return question
+                })]
+            }
+        })
     }
 
-    const { mcqs, setMcqs } = useQuiz();
-    // mcqs = {
-    //     step: 0,
-    //     questions: [
-    //     { id: 1, title: 'What is your name?'..... },
-    //     { id: 2, title: 'What do you do?' },
-    //     { id: 3, title: 'Where you from?' }
-    //     ]
-    // }
-
-    useEffect(() => {
-        return () => {
-            console.log("correctCount is - ", correctCount)
-        }
-
-    }, [])
 
     function previousQuestion() {
         if (mcqs.step === 0) return //should not go further prev if first question
@@ -46,29 +43,30 @@ export default function QuizPage() {
     }
 
     function nextQuestion() {
-        if (mcqs.step === (mcqs.questions.length - 1)) return //shouldn't go forward if last question
+        if (mcqs.step === (mcqs.questions.length - 1)){
+            //shouldn't go forward if last question, it should go to result page
+            navigate("/results-page")
+        } 
         setMcqs(prev => ({ ...prev, step: prev.step + 1 }))
     }
 
-    // console.log("mcqs are - ", mcqs)
-    // console.log(mcqs.step)
-    // console.log(mcqs.questions[mcqs.step].question)
+    console.log("correctCount before return: ", correctCount)
     return (
         <div>
             <h1>I am quiz page</h1>
             <h3>Question : {mcqs.questions[mcqs.step].question}</h3>
 
             <p
-                onClick={() => checkAnswer(mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[0])}
+                onClick={() => checkAnswer(mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[0], mcqs.questions[mcqs.step]._id)}
             >A. {mcqs.questions[mcqs.step].options[0]}</p>
             <p
-                onClick={() => checkAnswer(mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[1])}
+                onClick={() => checkAnswer( mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[1], mcqs.questions[mcqs.step]._id)}
             >B. {mcqs.questions[mcqs.step].options[1]}</p>
             <p
-                onClick={() => checkAnswer(mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[2])}
+                onClick={() => checkAnswer( mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[2], mcqs.questions[mcqs.step]._id)}
             >C. {mcqs.questions[mcqs.step].options[2]}</p>
             <p
-                onClick={() => checkAnswer(mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[3])}
+                onClick={() => checkAnswer( mcqs.questions[mcqs.step].answer, mcqs.questions[mcqs.step].options[3], mcqs.questions[mcqs.step]._id)}
             >D. {mcqs.questions[mcqs.step].options[3]}</p>
 
             <button onClick={() => previousQuestion()}>previous</button>

--- a/src/pages/results-page/ResultsPage.jsx
+++ b/src/pages/results-page/ResultsPage.jsx
@@ -1,0 +1,53 @@
+import "./results-page.css"
+import { useQuiz } from "../../context/quiz-context"
+
+export default function ResultsPage() {
+
+    const {mcqs, correctCount} = useQuiz();
+    const {questions} = mcqs;
+
+    function optionClicked(questionItem, optionIdx){
+
+        let returnStr = ''
+
+        //on clicked option - check if green or red
+        if(questionItem.options[optionIdx] === questionItem.clicked){
+
+            //clickedOption is the correct option
+            if(questionItem.options[optionIdx] === questionItem.answer){
+                return returnStr = "correct-clicked"
+            }else{
+                //clicked option is not the correct option
+                return returnStr = "wrong-clicked"
+            }
+        }
+
+        //if current option is the right option
+        if(questionItem.options[optionIdx] === questionItem.answer){
+            return returnStr = "correct-option"
+        }
+
+        return returnStr = "normal"
+    }
+
+    
+    return (
+        <div>
+            <h1>I am Results Page</h1>
+            <h2>Correct Count : {correctCount}</h2>
+            {questions.map((item, idx) => 
+                <div key={idx}>
+                    <h3>Question: {item.question}</h3>
+                    {item.options.map((option, optionIdx )=> 
+                        <p key={optionIdx}
+                        className={`
+                        ${optionClicked(item, optionIdx)}
+                        `}
+
+                        >{idx+1}. {option}</p>
+                    )}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/pages/results-page/ResultsPage.jsx
+++ b/src/pages/results-page/ResultsPage.jsx
@@ -3,48 +3,49 @@ import { useQuiz } from "../../context/quiz-context"
 
 export default function ResultsPage() {
 
-    const {mcqs, correctCount} = useQuiz();
-    const {questions} = mcqs;
+    const { mcqs, correctCount } = useQuiz();
+    const { questions } = mcqs;
 
-    function optionClicked(questionItem, optionIdx){
+    function optionClicked(questionItem, optionIdx) {
 
         let returnStr = ''
 
         //on clicked option - check if green or red
-        if(questionItem.options[optionIdx] === questionItem.clicked){
+        if (questionItem.options[optionIdx] === questionItem.clicked) {
 
             //clickedOption is the correct option
-            if(questionItem.options[optionIdx] === questionItem.answer){
+            if (questionItem.options[optionIdx] === questionItem.answer) {
                 return returnStr = "correct-clicked"
-            }else{
+            } else {
                 //clicked option is not the correct option
                 return returnStr = "wrong-clicked"
             }
         }
 
         //if current option is the right option
-        if(questionItem.options[optionIdx] === questionItem.answer){
+        if (questionItem.options[optionIdx] === questionItem.answer) {
             return returnStr = "correct-option"
         }
 
         return returnStr = "normal"
     }
 
-    
+
     return (
         <div>
             <h1>I am Results Page</h1>
             <h2>Correct Count : {correctCount}</h2>
-            {questions.map((item, idx) => 
+
+            {questions.map((item, idx) =>
                 <div key={idx}>
                     <h3>Question: {item.question}</h3>
-                    {item.options.map((option, optionIdx )=> 
+                    {item.options.map((option, optionIdx) =>
                         <p key={optionIdx}
-                        className={`
+                            className={`
                         ${optionClicked(item, optionIdx)}
-                        `}
-
-                        >{idx+1}. {option}</p>
+                        `}>
+                            {optionIdx + 1}. {option}
+                        </p>
                     )}
                 </div>
             )}

--- a/src/pages/results-page/results-page.css
+++ b/src/pages/results-page/results-page.css
@@ -1,0 +1,18 @@
+.correct-option{
+    border: 1px solid black;
+    background-color: green;
+}
+
+.correct-clicked{
+    border: 1px solid black;
+    background-color: green;
+}
+
+.normal{
+   border: 1px solid salmon; 
+}
+
+.wrong-clicked{
+    border: 1px solid black;
+    background-color: red;
+}


### PR DESCRIPTION
Result Page functionality added

- user can view the results in the Results Page
- Only working logic added
- Styling and Routing to be done later

Files to check 
- `src/pages/results-page`

How to test the PR
- In the landing page, click `Lets Go` -> click on `play now` -> after last question(`next` for next question), user will be on `Results Page`

[Live Preview](https://deploy-preview-5--popcorn-quiz.netlify.app/)